### PR TITLE
Fix: Get Stake details check stake window is open / not

### DIFF
--- a/airdrop/application/services/airdrop_services.py
+++ b/airdrop/application/services/airdrop_services.py
@@ -133,19 +133,19 @@ class AirdropServices:
                 contract_address, user_wallet_address)
 
             is_stakable, stakable_amount, tranfer_to_wallet = self.get_stake_and_claimable_amounts(
-                airdrop_rewards, is_stake_window_is_open, max_stake_amount, is_user_can_stake, already_staked_amount)
+                airdrop_rewards, is_stake_window_is_open, max_stake_amount, already_staked_amount)
 
             return is_stakable, stakable_amount, tranfer_to_wallet
         except BaseException as e:
             raise e("Exception on get_stake_info {}".format(e))
 
-    def get_stake_and_claimable_amounts(self, airdrop_rewards, is_stake_window_is_open, max_stake_amount, is_user_can_stake, already_staked_amount):
-        # User can stake if stake window is open and user can stake
-        is_stakable = True if is_user_can_stake and is_stake_window_is_open else False
+    def get_stake_and_claimable_amounts(self, airdrop_rewards, is_stake_window_is_open, max_stake_amount, already_staked_amount):
+
         tranfer_to_wallet = 0
         stakable_amount = 0
 
-        if is_stakable:
+        # User can stake if stake window is open and user can stake
+        if is_stake_window_is_open:
             allowed_amount_for_stake = max_stake_amount - already_staked_amount
             if(airdrop_rewards <= allowed_amount_for_stake):
                 # If airdrop rewards is less than allowed amount for stake then stake the full airdrop rewards
@@ -158,7 +158,7 @@ class AirdropServices:
         else:
             tranfer_to_wallet = airdrop_rewards
 
-        return is_stakable, stakable_amount, tranfer_to_wallet
+        return is_stake_window_is_open, stakable_amount, tranfer_to_wallet
 
     def get_stake_details_of_address(self, contract_address, user_wallet):
         try:

--- a/airdrop/application/services/airdrop_services.py
+++ b/airdrop/application/services/airdrop_services.py
@@ -97,20 +97,20 @@ class AirdropServices:
             airdrop_id = inputs["airdrop_id"]
             airdrop_window_id = inputs["airdrop_id"]
 
-            address = get_checksum_address(user_address)
+            user_wallet_address = get_checksum_address(user_address)
 
             rewards, user_address, contract_address, token_address, staking_contract_address = AirdropRepository().get_airdrop_window_claimable_info(
-                airdrop_id, airdrop_window_id, address)
+                airdrop_id, airdrop_window_id, user_wallet_address)
 
             staking_contract_address, stakable_token_name = AirdropRepository(
             ).get_staking_contract_address(airdrop_id)
 
             is_stakable, stakable_amount, tranfer_to_wallet = self.get_stake_info(
-                staking_contract_address, address, int(rewards))
+                staking_contract_address, user_wallet_address, int(rewards))
             stakable_tokens = stakable_amount
 
             stake_details = AirdropFactory.convert_stake_claim_details_to_model(
-                airdrop_id, airdrop_window_id, address, tranfer_to_wallet, stakable_tokens, is_stakable, stakable_token_name)
+                airdrop_id, airdrop_window_id, user_wallet_address, tranfer_to_wallet, stakable_tokens, is_stakable, stakable_token_name)
 
             response = {"stake_details": stake_details}
             status = HTTPStatus.OK
@@ -123,14 +123,14 @@ class AirdropServices:
 
         return status, response
 
-    def get_stake_info(self, contract_address, address, airdrop_rewards):
+    def get_stake_info(self, contract_address, user_wallet_address, airdrop_rewards):
         try:
 
             is_stake_window_is_open, max_stake_amount = self.get_stake_window_details(
                 contract_address)
 
             is_user_can_stake, already_staked_amount = self.get_stake_details_of_address(
-                contract_address, address)
+                contract_address, user_wallet_address)
 
             is_stakable, stakable_amount, tranfer_to_wallet = self.get_stake_and_claimable_amounts(
                 airdrop_rewards, is_stake_window_is_open, max_stake_amount, is_user_can_stake, already_staked_amount)
@@ -142,17 +142,21 @@ class AirdropServices:
     def get_stake_and_claimable_amounts(self, airdrop_rewards, is_stake_window_is_open, max_stake_amount, is_user_can_stake, already_staked_amount):
         # User can stake if stake window is open and user can stake
         is_stakable = True if is_user_can_stake and is_stake_window_is_open else False
+        tranfer_to_wallet = 0
+        stakable_amount = 0
 
-        allowed_amount_for_stake = max_stake_amount - already_staked_amount
+        if is_stakable:
+            allowed_amount_for_stake = max_stake_amount - already_staked_amount
+            if(airdrop_rewards <= allowed_amount_for_stake):
+                # If airdrop rewards is less than allowed amount for stake then stake the full airdrop rewards
+                stakable_amount = airdrop_rewards
+            else:
+                stakable_amount = allowed_amount_for_stake
 
-        if(airdrop_rewards <= allowed_amount_for_stake):
-            # If airdrop rewards is less than allowed amount for stake then stake the full airdrop rewards
-            stakable_amount = airdrop_rewards
+            # Amount user can claim to wallet after staking
+            tranfer_to_wallet = airdrop_rewards - stakable_amount
         else:
-            stakable_amount = allowed_amount_for_stake
-
-        # Amount user can claim to wallet after staking
-        tranfer_to_wallet = airdrop_rewards - stakable_amount
+            tranfer_to_wallet = airdrop_rewards
 
         return is_stakable, stakable_amount, tranfer_to_wallet
 

--- a/airdrop/infrastructure/repositories/airdrop_repository.py
+++ b/airdrop/infrastructure/repositories/airdrop_repository.py
@@ -225,7 +225,7 @@ class AirdropRepository(BaseRepository):
 
     def fetch_total_rewards_amount(self, airdrop_id, address):
         try:
-            query = text("select sum(ur.rewards_awarded) AS 'total_rewards' FROM user_rewards ur, airdrop_window aw where ur.airdrop_window_id = aw.row_id and ur.address = :address and aw.airdrop_id = :airdrop_id and aw.claim_start_period <= current_timestamp and exists ( select 1 from airdrop_window aw3 where current_timestamp <= aw3.claim_end_period and aw3.airdrop_id = :airdrop_id and aw3.claim_start_period <= current_timestamp ) and ur.airdrop_window_id > ( select ifnull (max(airdrop_window_id), -1) from claim_history where address = :address and transaction_status in ('SUCCESS', 'PENDING')) and ur.airdrop_window_id in ( SELECT airdrop_window_id FROM user_registrations ur2 WHERE ur2.address = :address and ur2.airdrop_window_id in ( select row_id from airdrop_window aw2 where aw2.airdrop_id = :airdrop_id));")
+            query = text("select sum(ur.rewards_awarded) AS 'total_rewards' FROM user_rewards ur, airdrop_window aw where ur.airdrop_window_id = aw.row_id and ur.address = :address and aw.airdrop_id = :airdrop_id and aw.claim_start_period <= current_timestamp and ur.airdrop_window_id not in (select airdrop_window_id from claim_history where address = :address and transaction_status in ('SUCCESS', 'PENDING')) and ur.airdrop_window_id > (select ifnull (max(airdrop_window_id), -1) from claim_history where address = :address and transaction_status in ('SUCCESS', 'PENDING'));")
             result = self.session.execute(
                 query, {'address': address, 'airdrop_id': airdrop_id})
             self.session.commit()

--- a/airdrop/testcases/unit_testcases/test_airdrop_claims.py
+++ b/airdrop/testcases/unit_testcases/test_airdrop_claims.py
@@ -190,7 +190,50 @@ class AirdropClaims(TestCase):
     @patch('airdrop.infrastructure.repositories.airdrop_repository.AirdropRepository.get_airdrop_window_claimable_info')
     @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_window_details')
     @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_details_of_address')
-    def test_get_airdrop_window_stake_details_partially_stake_and_claim(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
+    def test_get_airdrop_window_stake_details_by_sending_full_rewards_to_wallet_if_stake_window_is_not_open(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
+
+        user_wallet_address = "0x46EF7d49aaA68B29C227442BDbD18356415f8304"
+        contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+        token_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+        staking_contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+
+        is_stake_window_open = False
+        is_user_can_stake = True
+
+        max_stakable_amount = 10000
+        already_staked_amount = 0
+        airdrop_rewards = 20000
+
+        mock_get_stake_window_details.return_value = is_stake_window_open, max_stakable_amount
+        mock_get_stake_details_of_address.return_value = is_user_can_stake, already_staked_amount
+        mock_get_airdrop_window_claimable_info.return_value = airdrop_rewards, user_wallet_address, contract_address, token_address, staking_contract_address
+
+        event = {
+            "address": user_wallet_address,
+            "airdrop_id": "1",
+            "airdrop_window_id": "1"
+        }
+
+        expected_result = {
+            "stake_details": {
+                "airdrop_id": "1",
+                "airdrop_window_id": "1",
+                "address": user_wallet_address,
+                "claimable_tokens_to_wallet": airdrop_rewards,
+                "stakable_tokens": 0,
+                "is_stakable": False,
+                "stakable_token_name": "AGIX"
+            }
+        }
+
+        status_code, response = AirdropServices().get_airdrop_window_stake_details(event)
+        self.assertEqual(response, expected_result)
+        self.assertEqual(status_code, HTTPStatus.OK.value)
+
+    @patch('airdrop.infrastructure.repositories.airdrop_repository.AirdropRepository.get_airdrop_window_claimable_info')
+    @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_window_details')
+    @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_details_of_address')
+    def test_get_airdrop_window_stake_details_by_sending_full_rewards_to_wallet_as_user_exceeded_the_stake_limit(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
 
         user_wallet_address = "0x46EF7d49aaA68B29C227442BDbD18356415f8304"
         contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
@@ -201,7 +244,50 @@ class AirdropClaims(TestCase):
         is_user_can_stake = True
 
         max_stakable_amount = 10000
-        already_staked_amount = 2000
+        already_staked_amount = max_stakable_amount
+        airdrop_rewards = 20000
+
+        mock_get_stake_window_details.return_value = is_stake_window_open, max_stakable_amount
+        mock_get_stake_details_of_address.return_value = is_user_can_stake, already_staked_amount
+        mock_get_airdrop_window_claimable_info.return_value = airdrop_rewards, user_wallet_address, contract_address, token_address, staking_contract_address
+
+        event = {
+            "address": user_wallet_address,
+            "airdrop_id": "1",
+            "airdrop_window_id": "1"
+        }
+
+        expected_result = {
+            "stake_details": {
+                "airdrop_id": "1",
+                "airdrop_window_id": "1",
+                "address": user_wallet_address,
+                "claimable_tokens_to_wallet": airdrop_rewards,
+                "stakable_tokens": 0,
+                "is_stakable": True,
+                "stakable_token_name": "AGIX"
+            }
+        }
+
+        status_code, response = AirdropServices().get_airdrop_window_stake_details(event)
+        self.assertEqual(response, expected_result)
+        self.assertEqual(status_code, HTTPStatus.OK.value)
+
+    @patch('airdrop.infrastructure.repositories.airdrop_repository.AirdropRepository.get_airdrop_window_claimable_info')
+    @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_window_details')
+    @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_details_of_address')
+    def test_get_airdrop_window_stake_details_by_partially_stake_and_claim(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
+
+        user_wallet_address = "0x46EF7d49aaA68B29C227442BDbD18356415f8304"
+        contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+        token_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+        staking_contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+
+        is_stake_window_open = True
+        is_user_can_stake = True
+
+        max_stakable_amount = 10000
+        already_staked_amount = 5000
         airdrop_rewards = 10000
 
         mock_get_stake_window_details.return_value = is_stake_window_open, max_stakable_amount
@@ -219,8 +305,8 @@ class AirdropClaims(TestCase):
                 "airdrop_id": "1",
                 "airdrop_window_id": "1",
                 "address": user_wallet_address,
-                "claimable_tokens_to_wallet": 2000,
-                "stakable_tokens": 8000,
+                "claimable_tokens_to_wallet": 5000,
+                "stakable_tokens": 5000,
                 "is_stakable": True,
                 "stakable_token_name": "AGIX"
             }
@@ -233,7 +319,7 @@ class AirdropClaims(TestCase):
     @patch('airdrop.infrastructure.repositories.airdrop_repository.AirdropRepository.get_airdrop_window_claimable_info')
     @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_window_details')
     @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_details_of_address')
-    def test_get_airdrop_window_stake_details_by_completely_staking(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
+    def test_get_airdrop_window_stake_details_by_full_rewards_staked(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
 
         user_wallet_address = "0x46EF7d49aaA68B29C227442BDbD18356415f8304"
         contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
@@ -276,7 +362,7 @@ class AirdropClaims(TestCase):
     @patch('airdrop.infrastructure.repositories.airdrop_repository.AirdropRepository.get_airdrop_window_claimable_info')
     @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_window_details')
     @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_details_of_address')
-    def test_get_airdrop_window_stake_details_by_claiming_only(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
+    def test_get_airdrop_window_stake_details_if_airdrop_rewards_greater_than_max_stake_amount(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
 
         user_wallet_address = "0x46EF7d49aaA68B29C227442BDbD18356415f8304"
         contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
@@ -287,8 +373,8 @@ class AirdropClaims(TestCase):
         is_user_can_stake = True
 
         max_stakable_amount = 10000
-        already_staked_amount = max_stakable_amount
-        airdrop_rewards = 10000
+        already_staked_amount = 0
+        airdrop_rewards = 50000
 
         mock_get_stake_window_details.return_value = is_stake_window_open, max_stakable_amount
         mock_get_stake_details_of_address.return_value = is_user_can_stake, already_staked_amount
@@ -305,8 +391,8 @@ class AirdropClaims(TestCase):
                 "airdrop_id": "1",
                 "airdrop_window_id": "1",
                 "address": user_wallet_address,
-                "claimable_tokens_to_wallet": airdrop_rewards,
-                "stakable_tokens": 0,
+                "claimable_tokens_to_wallet": 40000,
+                "stakable_tokens": 10000,
                 "is_stakable": True,
                 "stakable_token_name": "AGIX"
             }

--- a/airdrop/testcases/unit_testcases/test_airdrop_claims.py
+++ b/airdrop/testcases/unit_testcases/test_airdrop_claims.py
@@ -402,6 +402,49 @@ class AirdropClaims(TestCase):
         self.assertEqual(response, expected_result)
         self.assertEqual(status_code, HTTPStatus.OK.value)
 
+    @patch('airdrop.infrastructure.repositories.airdrop_repository.AirdropRepository.get_airdrop_window_claimable_info')
+    @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_window_details')
+    @patch('airdrop.application.services.airdrop_services.AirdropServices.get_stake_details_of_address')
+    def test_get_airdrop_window_stake_details_user_can_stake_who_has_not_staked(self, mock_get_stake_details_of_address, mock_get_stake_window_details, mock_get_airdrop_window_claimable_info):
+
+        user_wallet_address = "0x46EF7d49aaA68B29C227442BDbD18356415f8304"
+        contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+        token_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+        staking_contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
+
+        is_stake_window_open = True
+        is_user_can_stake = True
+
+        max_stakable_amount = 10000
+        already_staked_amount = 0
+        airdrop_rewards = 10000
+
+        mock_get_stake_window_details.return_value = is_stake_window_open, max_stakable_amount
+        mock_get_stake_details_of_address.return_value = is_user_can_stake, already_staked_amount
+        mock_get_airdrop_window_claimable_info.return_value = airdrop_rewards, user_wallet_address, contract_address, token_address, staking_contract_address
+
+        event = {
+            "address": user_wallet_address,
+            "airdrop_id": "1",
+            "airdrop_window_id": "1"
+        }
+
+        expected_result = {
+            "stake_details": {
+                "airdrop_id": "1",
+                "airdrop_window_id": "1",
+                "address": user_wallet_address,
+                "claimable_tokens_to_wallet": 0,
+                "stakable_tokens": 10000,
+                "is_stakable": True,
+                "stakable_token_name": "AGIX"
+            }
+        }
+
+        status_code, response = AirdropServices().get_airdrop_window_stake_details(event)
+        self.assertEqual(response, expected_result)
+        self.assertEqual(status_code, HTTPStatus.OK.value)
+
     def test_airdrop_txn_watcher(self):
 
         response = AirdropServices().airdrop_txn_watcher()

--- a/airdrop/testcases/unit_testcases/test_airdrop_claims.py
+++ b/airdrop/testcases/unit_testcases/test_airdrop_claims.py
@@ -413,14 +413,14 @@ class AirdropClaims(TestCase):
         staking_contract_address = '0x5e94577b949a56279637ff74dfcff2c28408f049'
 
         is_stake_window_open = True
-        is_user_can_stake = True
+        is_already_staked_user = False
 
         max_stakable_amount = 10000
         already_staked_amount = 0
         airdrop_rewards = 10000
 
         mock_get_stake_window_details.return_value = is_stake_window_open, max_stakable_amount
-        mock_get_stake_details_of_address.return_value = is_user_can_stake, already_staked_amount
+        mock_get_stake_details_of_address.return_value = is_already_staked_user, already_staked_amount
         mock_get_airdrop_window_claimable_info.return_value = airdrop_rewards, user_wallet_address, contract_address, token_address, staking_contract_address
 
         event = {


### PR DESCRIPTION
1. Fix the unnecessary check on whether stake window is open & user is already claimed 
2. Remove unnecessary SQL queries and get rewards from method `fetch_total_rewards_amount`