### PR TITLE
Fix: Txn watcher not processing events

### DIFF
--- a/airdrop/application/services/airdrop_services.py
+++ b/airdrop/application/services/airdrop_services.py
@@ -20,6 +20,7 @@ class AirdropServices:
     def airdrop_txn_watcher(self):
 
         pending_txns = AirdropRepository().get_pending_txns()
+        print(f"pending_txns {len(pending_txns)}")
 
         for txn in pending_txns:
             try:

--- a/airdrop/infrastructure/repositories/airdrop_repository.py
+++ b/airdrop/infrastructure/repositories/airdrop_repository.py
@@ -30,6 +30,8 @@ class AirdropRepository(BaseRepository):
             pending_txns = (
                 self.session.query(ClaimHistory)
                 .filter(ClaimHistory.transaction_status == AirdropClaimStatus.PENDING.value)
+                .order_by(ClaimHistory.id.desc())
+                .limit(5)
                 .all()
             )
             self.session.commit()

--- a/airdrop/infrastructure/repositories/airdrop_repository.py
+++ b/airdrop/infrastructure/repositories/airdrop_repository.py
@@ -30,7 +30,7 @@ class AirdropRepository(BaseRepository):
             pending_txns = (
                 self.session.query(ClaimHistory)
                 .filter(ClaimHistory.transaction_status == AirdropClaimStatus.PENDING.value)
-                .order_by(ClaimHistory.id.desc())
+                .order_by(ClaimHistory.id.asc())
                 .limit(5)
                 .all()
             )


### PR DESCRIPTION
Issue:

Txn watcher is unable to validate pending txns due to lambda timeout. 
Txn watcher is executing a SQL query without any limits and on the fly we are making a blockchain call to check the status of the txn. So some unindexed txns are kept checking and causing the issue of not updating